### PR TITLE
Adjusted the indentation of chapters and sections.

### DIFF
--- a/vcd_installation_guide/topics/adding-vcd-provider.adoc
+++ b/vcd_installation_guide/topics/adding-vcd-provider.adoc
@@ -1,4 +1,4 @@
-= Adding a VMware vCloudDirector in Red Hat CloudForms
+== Adding a VMware vCloudDirector in Red Hat CloudForms
 
 Now that CloudForms, VMware vCloudDirector and RabbitMQ (optional) has been correctly installed, it
 is time to add the vCloudDirector as a CloudForms Cloud Provider.

--- a/vcd_installation_guide/topics/overview.adoc
+++ b/vcd_installation_guide/topics/overview.adoc
@@ -1,3 +1,3 @@
-= Overview
+== Overview
 
 This documentation includes the installation steps for VMware vCloudDirector provider into Red Hat CloudForms. The functionality covered by CloudForms plug-in for vCloudDirector provider is described in link:vcd-release-notes.adoc[Release Notes].

--- a/vcd_installation_guide/topics/prerequisite.adoc
+++ b/vcd_installation_guide/topics/prerequisite.adoc
@@ -1,4 +1,4 @@
-= Prerequisite
+== Prerequisite
 
 To include vCloudDirector provider into the Red Hat CloudForms, the following pieces are required to be installed:
 

--- a/vcd_installation_guide/topics/vcd-amqp.adoc
+++ b/vcd_installation_guide/topics/vcd-amqp.adoc
@@ -1,4 +1,4 @@
-= Enable AMQP Events in vCloudDirector
+== Enable AMQP Events in vCloudDirector
 
 To enable events from vCloudDirector, the following configuration in vCloudDirector is required. Prerequisite for this step is installed and configured RabbitMQ. For details, please refer to
 link:../topics/vcd-rabbitmq.adoc[Event Monitoring with RabbitMQ guide]

--- a/vcd_installation_guide/topics/vcd-rabbitmq.adoc
+++ b/vcd_installation_guide/topics/vcd-rabbitmq.adoc
@@ -1,15 +1,15 @@
-= Event Monitoring with RabbitMQ
+== Event Monitoring with RabbitMQ
 
 NOTE: this step is optional. It is appropriate in environments where vCloudDirector events will be pushed through RabbitMQ.
 
-== An Overview
+=== An Overview
 The VMware vCloudDirector (vCD) can distribute events and notifications to other AMQP server allowing the distribution of messages to other clients, in our case RedHat CloudForms or ManageIQ. Please find below the schema of this setting. Please note that the steps in this manual must be repeated for each vCD organization that you want to support Notifications for.
 
 .Image Title
 image::../../images/docs_vcd_rabbitmq01_overview.jpg[title="Schematic representation of the desired ManageIQ/CloudForms configuration."]
 
 
-== Prerequisites
+=== Prerequisites
 We assume that vCD is already deployed with corresponding RabbitMQ installation and that you
 have superuser access to both of them. Furthermore, we assume that vCD already sends messages
 with notifications to the RabbitMQ – hence exchange named systemExchange already exists inside
@@ -18,7 +18,7 @@ RabbitMQ.
 We also assume that RabbitMQ has Web GUI installed, although all the configuration below can be
 done via RabbitMQ CLI.
 
-== Obtain UUID of the organization
+=== Obtain UUID of the organization
 
 Notification messages that are dropped at RabbitMQ are routed by vCD organization UUID
 (ORG_UUID). In this section we provide instruction how to get UUID for a specific organization using
@@ -40,9 +40,9 @@ image::../../images/docs_vcd_rabbitmq03_chooseOrg.jpg[title="Select an organizat
 .Image Title
 image::../../images/docs_vcd_rabbitmq04_orgID.jpg[title="ORG_UUID can be seen on the organization details view, since it's part of the URL."]
 
-== Prepare queue for organisation
+=== Prepare queue for organisation
 
-=== Create
+==== Create
 Navigate to Queues tab and add a new queue there, to the same Virtual host as systemExchange.
 Name it `queue-<ORG_UUID>` and leave all other parameters on default.
 
@@ -52,7 +52,7 @@ image::../../images/docs_vcd_rabbitmq05_setQueue.jpg[title="Adding a new queue i
 IMPORTANT: Please set parameters exactly as shown in the screenshot above, otherwise ManageIQ
 will not be able to consume messages (e.g. if you set auto delete to true instead of false).
 
-=== Subscribe
+==== Subscribe
 Navigate to Exchanges tab and open up vCloud Directors systemExchange details (prefixed with `vcd` as set in AMQP broker configuration). In the Bindings subsection add
 binding for your queue with following routing key: `##.<ORG_UUID>#`.
 
@@ -62,8 +62,8 @@ image::../../images/docs_vcd_rabbitmq06_bindQueue.jpg[title="Binding exchange to
 Your queue will now receive all messages regarding specified organization. As a last step we need to
 add user.
 
-== Prepare user for organisation
-=== Create
+=== Prepare user for organisation
+==== Create
 Navigate to Admin tab and add a new user without any tags. Omitting all tags restricts user to
 connect only to the specific queue. Please note that she will not be able to access the RabbitMQ Web
 UI as well.
@@ -71,7 +71,7 @@ UI as well.
 .Image Title
 image::../../images/docs_vcd_rabbitmq07_orgUser.jpg[title="Adding a new RabbitMQ user without any tags."]
 
-=== Configure
+==== Configure
 Open up user details and set Configure, Write and Read permission in Permissions subsection. For all
 three of them simply use queue name and set the permission.
 
@@ -81,7 +81,7 @@ image::../../images/docs_vcd_rabbitmq08_permissions.jpg[title="Tuning permission
 IMPORTANT: Make sure that you click “Set permission” button after you’ve input queue names or
 else user will not be able to consume any messages.
 
-== Summary
+=== Summary
 Following instructions above the RabbitMQ is configured so that it is safe to provide vCD organization
 administrator with RabbitMQ endpoint URL and credentials of the created user. She will only be able
 to connect to the queue that is prepared for her and therefore only consume messages related to

--- a/vcd_installation_guide/topics/vcd-release-notes.adoc
+++ b/vcd_installation_guide/topics/vcd-release-notes.adoc
@@ -1,4 +1,4 @@
-= vCloudDirector Plugin release notes
+== vCloudDirector Plugin release notes
 
 .Red Hat CloudForms have a plug-in for vCloudDirector provider with limited functionality. The vCloudDirector coverage is limited to the following functionality:
 *  Authorization
@@ -9,11 +9,11 @@
 
 Due to the limited support of vCloudDirector provider, some functionalities are not straightforward. The most exceptional is provision of a VM. This is not possible even through the vCloudDirector without building the vApp. More details on this matter are in Provisioning section.
 
-== Authorization
+=== Authorization
 The authorization is a basic functionality that creates a link from CloudForms to vCloudDirector and enables collecting data from vCloudDirector. The Authorization is possible through vCloud director organization (tenant) accounts. More details on adding new provider are described in link:adding-vcd-provider.adoc[Add new vCloudDirector provider].
 
 
-== Inventory
+=== Inventory
 The inventory collects instances and catalog items. The results from this step are available in corresponding views:
 
 .Mapping (CloudForms view/vCloudDirector notation):
@@ -23,7 +23,7 @@ The inventory collects instances and catalog items. The results from this step a
 * Networks / Organization VDC Networks
 * Subnets / VDC Network pool
 
-== Power Operations
+=== Power Operations
 Power operations cover the control functionality over the VMs and vApps, similarly that you expect from other providers.
 
 .Service operations are:
@@ -38,11 +38,11 @@ Please note when retiring services all VMs in the service will be stopped and de
 * Suspend
 * Delete
 
-== Provisioning
+=== Provisioning
 The major difference of vCloudDirector provider from others is that it provisions all resources wrapped in vApps. The images, VMs and vApp templates can be stored in Organizational Catalog, but only vApps can be provisioned directly. To provision other resources, a corresponding vApp needs to be built first.
 
 The vCloudDirector provider for CloudForms has limited functionality and does not support building or changing vApps from CloudForms directly, therefore the vApp templates needs to be created in advance with vCloudDirector. The provision process of existing vApp is described in link:vcd-vapp-provision.adoc[vApp Provision in vCloudDirector through Red Hat CloudForms].
 
 
-== Events
+=== Events
 The events from vCloudDirector are published on RabbitMQ, which filters the events per Organization (tenant). In the CloudForms there is a tab for setting RabbitMQ credentials in provider's configuration form. More details on enabling RabbitMQ is described in link:vcd-rabbitmq.adoc[Event Monitoring with RabbitMQ].

--- a/vcd_installation_guide/topics/vcd-vapp-provision.adoc
+++ b/vcd_installation_guide/topics/vcd-vapp-provision.adoc
@@ -1,10 +1,10 @@
-= vApp Provision in vCloudDirector through Red Hat CloudForms
+== vApp Provision in vCloudDirector through Red Hat CloudForms
 
 The VMware vCloudDirector uses vApps as a basic entity on which power operations are performed. The vApp can include one or more virtual machines and in CloudForms a vApp is represented as a type of orchestration stack. User can find more information about vApps on link:https://pubs.vmware.com/vca/index.jsp?topic=%2Fcom.vmware.vca.od.ug.doc%2FGUID-3F4BF45F-89CE-4478-B6D5-5BD7EE749C08.html[VMware pages].
 
 Note: Currently CloudForms cannot change any attributes of a vApp or any virtual machines inside vApp. All vApp modification should be realized throug VMware vCloud Director.
 
-== Prerequisites
+=== Prerequisites
 .The vApp provision process requires:
 * Properly configured vCloudDirector:
  - Valid Organization
@@ -13,14 +13,14 @@ Note: Currently CloudForms cannot change any attributes of a vApp or any virtual
 * Properly configured CloudForms:
  - VMware Cloud provider added (vCloudDirector, organization level access)
 
-== vApp provision process
+=== vApp provision process
 The vApp provision process is comprised of several steps. First the Service Dialog is required to be created. After this the new Service Item to provision the vApp is added to the Catalog.
 
-=== Create a service dialog for vApp
+==== Create a service dialog for vApp
 In the CloudForms navigate to "Services>Catalogs>Orchestration templates". In "All Orchestration Templates" folder find "vApp templates" and choose vApp template. Now from Configuration menu choose "Create Service Dialog from Orchestration template". Choose the name of the Dialog and save the dialog.
 
 
-=== Create a Catalog item
+==== Create a Catalog item
 
 NOTE: This step assumes that there is at least one catalog already create.
 
@@ -38,6 +38,6 @@ image:../../images/vcd-vapp04-itemtype.png[alt="Select Orchestration stack"]
 
 Saving the from concludes the step of creating the catalog.
 
-=== Provision (order) vApp service
+==== Provision (order) vApp service
 
 In the CloudForms navigate to "Services>Catalogs>Service Catalog". Choose your preferred Catalog where you saved the vApp service item and "Order" the item. Choose stack (vApp) name, Select availability zone, vApp parameters and Network. Submit the order for approval.


### PR DESCRIPTION
Submitting a pull request to update the indentation of some of the main chapters and sections.

Unless the level offset is specified for each section that starts with a single '=', the sections need to be indented for each level to ensure they render correctly. If they are listed as just '=' with no level offset, they are considered 'parts'.